### PR TITLE
Bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.0",
     "nette/application": ">=2.2.0",
     "latte/latte": ">=2.2.0",
     "nette/tester": "^2.0",

--- a/src/BaseLogin.php
+++ b/src/BaseLogin.php
@@ -7,7 +7,7 @@ use Nette;
 
 class BaseLogin
 {
-    Nette\SmartObject;
+    use Nette\SmartObject;
 
     /** @var array params */
     protected $params;


### PR DESCRIPTION
While trying to use version 1.1 on my project, I found these two problems:

1) Bug in BaseLogin class (missing 'use' keyword)
2) Can figure out, why php 7.1. is required  (not by Nette or any other library, no php 7.1 features presented in current code)

This pull request should fix these problems    
