### PR TITLE
Fix not existing class in google/apiclient-services

### DIFF
--- a/src/GoogleLogin.php
+++ b/src/GoogleLogin.php
@@ -74,7 +74,7 @@ class GoogleLogin extends BaseLogin
 	/**
 	 * Return info about login user
 	 * @param $code
-	 * @return \Google_Service_Oauth2_Userinfoplus
+	 * @return \Google_Service_Oauth2_Userinfo
 	 * @throws Exception
 	 */
 	public function getMe($code)


### PR DESCRIPTION
Class `Google_Service_Oauth2_Userinfoplus` was removed from google/apiclient-services in version 0.128 (7 months ago).